### PR TITLE
Add interactive cout exercises

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,39 @@
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, session, redirect, url_for
 import subprocess
 import tempfile
 import os
+import difflib
 
 app = Flask(__name__)
+app.secret_key = 'dev-secret-key'
+
+# Simple exercises focused on using std::cout
+exercises = [
+    {
+        'title': 'Hello World',
+        'description': 'Write a program that prints "Hello, World!" using cout.',
+        'solution_code': '\n'.join([
+            '#include <iostream>',
+            'int main() {',
+            '    std::cout << "Hello, World!";',
+            '    return 0;',
+            '}'
+        ]),
+        'expected_output': 'Hello, World!'
+    },
+    {
+        'title': 'Print 1 to 5',
+        'description': 'Write a program that prints numbers 1 2 3 4 5 separated by spaces using cout.',
+        'solution_code': '\n'.join([
+            '#include <iostream>',
+            'int main() {',
+            '    std::cout << "1 2 3 4 5";',
+            '    return 0;',
+            '}'
+        ]),
+        'expected_output': '1 2 3 4 5'
+    }
+]
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
@@ -30,6 +60,52 @@ def compile_code(code: str) -> str:
             return 'Compilation succeeded.\nProgram output:\n' + run.stdout
         else:
             return 'Compilation failed:\n' + result.stderr
+
+
+@app.route('/exercises', methods=['GET', 'POST'])
+def exercises_view():
+    """Interactive exercises focused on using cout."""
+    idx = int(request.args.get('id', 0))
+    if idx < 0 or idx >= len(exercises):
+        return redirect(url_for('exercises_view', id=0))
+    exercise = exercises[idx]
+    code = ''
+    result = None
+
+    session.setdefault('attempts', {})
+    attempts = session['attempts'].get(str(idx), 0)
+
+    if request.method == 'POST':
+        code = request.form.get('code', '')
+        result = compile_code(code)
+        attempts += 1
+        session['attempts'][str(idx)] = attempts
+
+        # Provide feedback comparing actual program output with expected output
+        if 'Compilation succeeded' in result:
+            actual_output = ''
+            if 'Program output:\n' in result:
+                actual_output = result.split('Program output:\n', 1)[1].strip()
+            expected = exercise['expected_output']
+            if actual_output == expected:
+                result += '\nCorrect!'
+            else:
+                diff = '\n'.join(difflib.ndiff([expected], [actual_output]))
+                result += f"\nExpected output:\n{expected}\nDifferences:\n{diff}"
+        else:
+            result += f"\nExpected output:\n{exercise['expected_output']}"
+
+    show_solution = attempts >= 3
+    return render_template(
+        'exercises.html',
+        exercises=exercises,
+        idx=idx,
+        exercise=exercise,
+        code=code,
+        result=result,
+        attempts=attempts,
+        show_solution=show_solution
+    )
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/app/templates/exercises.html
+++ b/app/templates/exercises.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Exercises</title>
+    <style>
+        textarea { width: 100%; height: 300px; }
+        pre { background: #eee; padding: 10px; }
+    </style>
+</head>
+<body>
+    <h1>Exercises</h1>
+    <nav>
+        <ul>
+        {% for i, ex in enumerate(exercises) %}
+            <li><a href="{{ url_for('exercises_view', id=i) }}">{{ ex.title }}</a></li>
+        {% endfor %}
+        </ul>
+    </nav>
+    <h2>{{ exercise.title }}</h2>
+    <p>{{ exercise.description }}</p>
+
+    <form method="post">
+        <textarea name="code" placeholder="Enter your C++ code here">{{ code }}</textarea>
+        <br>
+        <button type="submit">Run</button>
+    </form>
+
+    {% if result %}
+    <h3>Result</h3>
+    <pre>{{ result }}</pre>
+    {% endif %}
+
+    {% if show_solution %}
+    <h3>Solution</h3>
+    <pre>{{ exercise.solution_code }}</pre>
+    {% else %}
+    <p>Attempts: {{ attempts }} (solution available after 3 attempts)</p>
+    {% endif %}
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
     <h1>Online C++ Grader</h1>
+    <p><a href="{{ url_for('exercises_view') }}">Try the cout exercises</a></p>
     <form method="post">
         <textarea name="code" placeholder="Enter your C++ code here">{{code}}</textarea>
         <br>


### PR DESCRIPTION
## Summary
- add interactive exercises exploring `cout`
- link to exercises from home page
- provide solution after three failed attempts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405332004c832e944db758b0450c5a