### PR TITLE
Add interactive cout exercises

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,39 @@
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, session, redirect, url_for
 import subprocess
 import tempfile
 import os
+import difflib
 
 app = Flask(__name__)
+app.secret_key = 'dev-secret-key'
+
+# Simple exercises focused on using std::cout
+exercises = [
+    {
+        'title': 'Hello World',
+        'description': 'Write a program that prints "Hello, World!" using cout.',
+        'solution_code': '\n'.join([
+            '#include <iostream>',
+            'int main() {',
+            '    std::cout << "Hello, World!";',
+            '    return 0;',
+            '}'
+        ]),
+        'expected_output': 'Hello, World!'
+    },
+    {
+        'title': 'Print 1 to 5',
+        'description': 'Write a program that prints numbers 1 2 3 4 5 separated by spaces using cout.',
+        'solution_code': '\n'.join([
+            '#include <iostream>',
+            'int main() {',
+            '    std::cout << "1 2 3 4 5";',
+            '    return 0;',
+            '}'
+        ]),
+        'expected_output': '1 2 3 4 5'
+    }
+]
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
@@ -30,6 +60,52 @@ def compile_code(code: str) -> str:
             return 'Compilation succeeded.\nProgram output:\n' + run.stdout
         else:
             return 'Compilation failed:\n' + result.stderr
+
+
+@app.route('/exercises', methods=['GET', 'POST'])
+def exercises_view():
+    """Interactive exercises focused on using cout."""
+    idx = int(request.args.get('id', 0))
+    if idx < 0 or idx >= len(exercises):
+        return redirect(url_for('exercises_view', id=0))
+    exercise = exercises[idx]
+    code = ''
+    result = None
+
+    session.setdefault('attempts', {})
+    attempts = session['attempts'].get(str(idx), 0)
+
+    if request.method == 'POST':
+        code = request.form.get('code', '')
+        result = compile_code(code)
+        attempts += 1
+        session['attempts'][str(idx)] = attempts
+
+        # Provide feedback comparing actual program output with expected output
+        if 'Compilation succeeded' in result:
+            actual_output = ''
+            if 'Program output:\n' in result:
+                actual_output = result.split('Program output:\n', 1)[1].strip()
+            expected = exercise['expected_output']
+            if actual_output == expected:
+                result += '\nCorrect!'
+            else:
+                diff = '\n'.join(difflib.ndiff([expected], [actual_output]))
+                result += f"\nExpected output:\n{expected}\nDifferences:\n{diff}"
+        else:
+            result += f"\nExpected output:\n{exercise['expected_output']}"
+
+    show_solution = attempts >= 3
+    return render_template(
+        'exercises.html',
+        exercises=exercises,
+        idx=idx,
+        exercise=exercise,
+        code=code,
+        result=result,
+        attempts=attempts,
+        show_solution=show_solution
+    )
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/app/main.py
+++ b/app/main.py
@@ -71,6 +71,15 @@ def compile_code(code: str) -> str:
             return 'Compilation failed:\n' + error_output
 
 
+@app.route('/api/compile', methods=['POST'])
+def api_compile():
+    """API endpoint for React front-end to compile code."""
+    data = request.get_json()
+    code = data.get('code', '')
+    output = compile_code(code)
+    return {'output': output}
+
+
 @app.route('/exercises', methods=['GET', 'POST'])
 def exercises_view():
     """Interactive exercises focused on using cout."""

--- a/app/static/exercises.js
+++ b/app/static/exercises.js
@@ -1,0 +1,24 @@
+(function() {
+  const { useEffect } = React;
+
+  function AceEditor() {
+    useEffect(() => {
+      const editor = ace.edit('editor');
+      editor.session.setMode('ace/mode/c_cpp');
+      editor.setTheme('ace/theme/monokai');
+      editor.setOptions({
+        enableBasicAutocompletion: true,
+        enableSnippets: true
+      });
+      const textarea = document.querySelector('textarea[name="code"]');
+      editor.session.setValue(textarea.value || '');
+      document.querySelector('form').addEventListener('submit', function() {
+        textarea.value = editor.getValue();
+      });
+      if (window.hljs) { hljs.highlightAll(); }
+    }, []);
+    return React.createElement('div', { id: 'editor', style: { width: '100%', height: '300px', border: '1px solid #ccc' } });
+  }
+
+  ReactDOM.createRoot(document.getElementById('editor-root')).render(React.createElement(AceEditor));
+})();

--- a/app/static/index.js
+++ b/app/static/index.js
@@ -1,0 +1,41 @@
+(function() {
+  const { useState, useEffect } = React;
+
+  function App() {
+    const [code, setCode] = useState('');
+    const [output, setOutput] = useState(null);
+
+    useEffect(() => {
+      const editor = ace.edit('editor');
+      editor.session.setMode('ace/mode/c_cpp');
+      editor.setTheme('ace/theme/monokai');
+      editor.setOptions({
+        enableBasicAutocompletion: true,
+        enableSnippets: true
+      });
+      editor.session.on('change', function() {
+        setCode(editor.getValue());
+      });
+    }, []);
+
+    async function compile() {
+      const res = await fetch('/api/compile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code })
+      });
+      const data = await res.json();
+      setOutput(data.output);
+      requestAnimationFrame(() => { if (window.hljs) { hljs.highlightAll(); } });
+    }
+
+    return React.createElement('div', { className: 'app-container' }, [
+      React.createElement('h1', { key: 'title' }, 'Online C++ Grader'),
+      React.createElement('div', { id: 'editor', key: 'editor', style: { height: '300px', width: '100%', border: '1px solid #ccc' } }),
+      React.createElement('button', { key: 'btn', onClick: compile }, 'Compile'),
+      output ? React.createElement('pre', { key: 'out', className: 'output' }, output) : null
+    ]);
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
+})();

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,41 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f4f4f4;
+  margin: 0;
+  padding: 0;
+}
+header {
+  background-color: #333;
+  color: white;
+  padding: 10px 20px;
+}
+.app-container {
+  max-width: 900px;
+  margin: 20px auto;
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+button {
+  margin-top: 10px;
+  padding: 8px 16px;
+}
+pre.output {
+  background: #eee;
+  padding: 10px;
+  white-space: pre-wrap;
+}
+nav ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 10px;
+}
+nav a {
+  color: #0069d9;
+  text-decoration: none;
+}
+nav a:hover {
+  text-decoration: underline;
+}

--- a/app/templates/exercises.html
+++ b/app/templates/exercises.html
@@ -2,63 +2,45 @@
 <html>
 <head>
     <title>Exercises</title>
-    <style>
-        #editor { width: 100%; height: 300px; border: 1px solid #ccc; }
-        textarea { display: none; }
-        pre { background: #eee; padding: 10px; }
-    </style>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/default.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/ace.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/ext-language_tools.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/snippets/c_cpp.min.js"></script>
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        hljs.highlightAll();
-        var editor = ace.edit('editor');
-        editor.session.setMode('ace/mode/c_cpp');
-        editor.setTheme('ace/theme/textmate');
-        editor.setOptions({
-          enableBasicAutocompletion: true,
-          enableSnippets: true
-        });
-        var textarea = document.querySelector('textarea[name="code"]');
-        editor.session.setValue(textarea.value || '');
-        document.querySelector('form').addEventListener('submit', function() {
-          textarea.value = editor.getValue();
-        });
-      });
-    </script>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
 </head>
 <body>
-    <h1>Exercises</h1>
-    <nav>
-        <ul>
-        {% for ex in exercises %}
-            <li><a href="{{ url_for('exercises_view', id=loop.index0) }}">{{ ex.title }}</a></li>
-        {% endfor %}
-        </ul>
-    </nav>
-    <h2>{{ exercise.title }}</h2>
-    <p>{{ exercise.description }}</p>
-
-    <form method="post">
-        <div id="editor">{{ code }}</div>
-        <textarea name="code" id="code">{{ code }}</textarea>
-        <br>
-        <button type="submit">Run</button>
-    </form>
-
-    {% if result %}
-    <h3>Result</h3>
-    <pre><code class="language-text">{{ result }}</code></pre>
-    {% endif %}
-
-    {% if show_solution %}
-    <h3>Solution</h3>
-    <pre><code class="language-cpp">{{ exercise.solution_code }}</code></pre>
-    {% else %}
-    <p>Attempts: {{ attempts }} (solution available after 3 attempts)</p>
-    {% endif %}
+    <header>
+        <nav>
+            <ul>
+                <li><a href="/">Home</a></li>
+                {% for ex in exercises %}
+                <li><a href="{{ url_for('exercises_view', id=loop.index0) }}">{{ ex.title }}</a></li>
+                {% endfor %}
+            </ul>
+        </nav>
+    </header>
+    <div class="app-container">
+        <h2>{{ exercise.title }}</h2>
+        <p>{{ exercise.description }}</p>
+        <form method="post">
+            <div id="editor-root"></div>
+            <textarea name="code" id="code">{{ code }}</textarea>
+            <br>
+            <button type="submit">Run</button>
+        </form>
+        {% if result %}
+        <h3>Result</h3>
+        <pre><code class="language-text">{{ result }}</code></pre>
+        {% endif %}
+        {% if show_solution %}
+        <h3>Solution</h3>
+        <pre><code class="language-cpp">{{ exercise.solution_code }}</code></pre>
+        {% else %}
+        <p>Attempts: {{ attempts }} (solution available after 3 attempts)</p>
+        {% endif %}
+    </div>
+    <script src="{{ url_for('static', filename='exercises.js') }}"></script>
 </body>
 </html>

--- a/app/templates/exercises.html
+++ b/app/templates/exercises.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Online C++ Grader</title>
+    <title>Exercises</title>
     <style>
         textarea { width: 100%; height: 300px; }
         pre { background: #eee; padding: 10px; }
@@ -36,16 +36,33 @@
     </script>
 </head>
 <body>
-    <h1>Online C++ Grader</h1>
-    <p><a href="{{ url_for('exercises_view') }}">Try the cout exercises</a></p>
+    <h1>Exercises</h1>
+    <nav>
+        <ul>
+        {% for ex in exercises %}
+            <li><a href="{{ url_for('exercises_view', id=loop.index0) }}">{{ ex.title }}</a></li>
+        {% endfor %}
+        </ul>
+    </nav>
+    <h2>{{ exercise.title }}</h2>
+    <p>{{ exercise.description }}</p>
+
     <form method="post">
-        <textarea name="code" placeholder="Enter your C++ code here">{{code}}</textarea>
+        <textarea name="code" placeholder="Enter your C++ code here">{{ code }}</textarea>
         <br>
-        <button type="submit">Compile</button>
+        <button type="submit">Run</button>
     </form>
-    {% if output %}
-    <h2>Result</h2>
-    <pre><code class="language-text">{{output}}</code></pre>
+
+    {% if result %}
+    <h3>Result</h3>
+    <pre><code class="language-text">{{ result }}</code></pre>
+    {% endif %}
+
+    {% if show_solution %}
+    <h3>Solution</h3>
+    <pre><code class="language-cpp">{{ exercise.solution_code }}</code></pre>
+    {% else %}
+    <p>Attempts: {{ attempts }} (solution available after 3 attempts)</p>
     {% endif %}
 </body>
 </html>

--- a/app/templates/exercises.html
+++ b/app/templates/exercises.html
@@ -3,34 +3,29 @@
 <head>
     <title>Exercises</title>
     <style>
-        textarea { width: 100%; height: 300px; }
+        #editor { width: 100%; height: 300px; border: 1px solid #ccc; }
+        textarea { display: none; }
         pre { background: #eee; padding: 10px; }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/default.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/ace.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/ext-language_tools.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/snippets/c_cpp.min.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', function() {
         hljs.highlightAll();
-        var t = document.querySelector('textarea[name="code"]');
-        if (!t) return;
-        t.addEventListener('keydown', function(e) {
-          if (e.key === 'Tab') {
-            e.preventDefault();
-            var start = this.selectionStart;
-            this.value = this.value.substring(0, start) + '    ' + this.value.substring(this.selectionEnd);
-            this.selectionStart = this.selectionEnd = start + 4;
-          } else if (e.key === 'Enter') {
-            var start = this.selectionStart;
-            var before = this.value.substring(0, start);
-            var prev = before.substring(before.lastIndexOf('\n') + 1);
-            var indent = prev.match(/^\s+/);
-            indent = indent ? indent[0] : '';
-            if (/\{\s*$/.test(prev)) indent += '    ';
-            e.preventDefault();
-            var insert = '\n' + indent;
-            this.value = before + insert + this.value.substring(this.selectionEnd);
-            this.selectionStart = this.selectionEnd = start + insert.length;
-          }
+        var editor = ace.edit('editor');
+        editor.session.setMode('ace/mode/c_cpp');
+        editor.setTheme('ace/theme/textmate');
+        editor.setOptions({
+          enableBasicAutocompletion: true,
+          enableSnippets: true
+        });
+        var textarea = document.querySelector('textarea[name="code"]');
+        editor.session.setValue(textarea.value || '');
+        document.querySelector('form').addEventListener('submit', function() {
+          textarea.value = editor.getValue();
         });
       });
     </script>
@@ -48,7 +43,8 @@
     <p>{{ exercise.description }}</p>
 
     <form method="post">
-        <textarea name="code" placeholder="Enter your C++ code here">{{ code }}</textarea>
+        <div id="editor">{{ code }}</div>
+        <textarea name="code" id="code">{{ code }}</textarea>
         <br>
         <button type="submit">Run</button>
     </form>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,46 +2,24 @@
 <html>
 <head>
     <title>Online C++ Grader</title>
-    <style>
-        #editor { width: 100%; height: 300px; border: 1px solid #ccc; }
-        textarea { display: none; }
-        pre { background: #eee; padding: 10px; }
-    </style>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/default.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/ace.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/ext-language_tools.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/snippets/c_cpp.min.js"></script>
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        hljs.highlightAll();
-        var editor = ace.edit('editor');
-        editor.session.setMode('ace/mode/c_cpp');
-        editor.setTheme('ace/theme/textmate');
-        editor.setOptions({
-          enableBasicAutocompletion: true,
-          enableSnippets: true
-        });
-        var textarea = document.querySelector('textarea[name="code"]');
-        editor.session.setValue(textarea.value || '');
-        document.querySelector('form').addEventListener('submit', function() {
-          textarea.value = editor.getValue();
-        });
-      });
-    </script>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
 </head>
 <body>
-    <h1>Online C++ Grader</h1>
-    <p><a href="{{ url_for('exercises_view') }}">Try the cout exercises</a></p>
-    <form method="post">
-        <div id="editor">{{code}}</div>
-        <textarea name="code" id="code">{{code}}</textarea>
-        <br>
-        <button type="submit">Compile</button>
-    </form>
-    {% if output %}
-    <h2>Result</h2>
-    <pre><code class="language-text">{{output}}</code></pre>
-    {% endif %}
+    <header>
+        <nav>
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li><a href="{{ url_for('exercises_view') }}">Exercises</a></li>
+            </ul>
+        </nav>
+    </header>
+    <div id="root"></div>
+    <script src="{{ url_for('static', filename='index.js') }}"></script>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,34 +3,29 @@
 <head>
     <title>Online C++ Grader</title>
     <style>
-        textarea { width: 100%; height: 300px; }
+        #editor { width: 100%; height: 300px; border: 1px solid #ccc; }
+        textarea { display: none; }
         pre { background: #eee; padding: 10px; }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/default.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/ace.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/ext-language_tools.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/snippets/c_cpp.min.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', function() {
         hljs.highlightAll();
-        var t = document.querySelector('textarea[name="code"]');
-        if (!t) return;
-        t.addEventListener('keydown', function(e) {
-          if (e.key === 'Tab') {
-            e.preventDefault();
-            var start = this.selectionStart;
-            this.value = this.value.substring(0, start) + '    ' + this.value.substring(this.selectionEnd);
-            this.selectionStart = this.selectionEnd = start + 4;
-          } else if (e.key === 'Enter') {
-            var start = this.selectionStart;
-            var before = this.value.substring(0, start);
-            var prev = before.substring(before.lastIndexOf('\n') + 1);
-            var indent = prev.match(/^\s+/);
-            indent = indent ? indent[0] : '';
-            if (/\{\s*$/.test(prev)) indent += '    ';
-            e.preventDefault();
-            var insert = '\n' + indent;
-            this.value = before + insert + this.value.substring(this.selectionEnd);
-            this.selectionStart = this.selectionEnd = start + insert.length;
-          }
+        var editor = ace.edit('editor');
+        editor.session.setMode('ace/mode/c_cpp');
+        editor.setTheme('ace/theme/textmate');
+        editor.setOptions({
+          enableBasicAutocompletion: true,
+          enableSnippets: true
+        });
+        var textarea = document.querySelector('textarea[name="code"]');
+        editor.session.setValue(textarea.value || '');
+        document.querySelector('form').addEventListener('submit', function() {
+          textarea.value = editor.getValue();
         });
       });
     </script>
@@ -39,7 +34,8 @@
     <h1>Online C++ Grader</h1>
     <p><a href="{{ url_for('exercises_view') }}">Try the cout exercises</a></p>
     <form method="post">
-        <textarea name="code" placeholder="Enter your C++ code here">{{code}}</textarea>
+        <div id="editor">{{code}}</div>
+        <textarea name="code" id="code">{{code}}</textarea>
         <br>
         <button type="submit">Compile</button>
     </form>


### PR DESCRIPTION
## Summary
- add interactive exercises exploring `cout`
- link to exercises from home page
- provide solution after three failed attempts
- fix navigation error and improve code layout

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68405332004c832e944db758b0450c5a